### PR TITLE
Install TagBot for automated package releases

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,21 @@
+name: TagBot
+
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        description: "[DEPRECATED] No longer has any effect"
+        default: "3"
+
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@14d7645453716d7a2f09b1da0504a024f97462a1 # v1.25.10
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
## Summary

- install the canonical Julia TagBot workflow
- pin TagBot to the current `v1.25.10` action commit
- reuse `DOCUMENTER_KEY` so tags created by TagBot can trigger the existing tag-based documentation workflow

## Validation

- copied the workflow structure from TagBot's canonical `example.yml`
- confirmed `DOCUMENTER_KEY` exists in this repository
- confirmed Actions has write workflow permissions
- `git diff --check` passes
