### PR TITLE
Add :era5_land dataset support and unwrap zip-wrapped CDS responses

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -15,6 +15,7 @@ submit_cds_request
 poll_request_status
 download_cds_file
 CopernicusClimateDataStore.request_with_retries
+CopernicusClimateDataStore.resolve_dataset
 ```
 
 ## Utility Functions

--- a/src/CopernicusClimateDataStore.jl
+++ b/src/CopernicusClimateDataStore.jl
@@ -7,10 +7,33 @@ export hourly, monthly, yearly
 include("cds_client.jl")
 
 """
+    resolve_dataset(dataset, pressure_levels)
+
+Resolve the `dataset` keyword (`:era5` or `:era5_land`) and optional pressure levels
+to a CDS dataset id and `product_type` value. Returns `(dataset_id, product_type)`,
+where `product_type` is `nothing` for datasets whose CDS requests take no
+`product_type` key (ERA5-Land).
+"""
+function resolve_dataset(dataset::Symbol, pressure_levels)
+    if dataset === :era5
+        dataset_id = isnothing(pressure_levels) ? "reanalysis-era5-single-levels" :
+                                                  "reanalysis-era5-pressure-levels"
+        return dataset_id, "reanalysis"
+    elseif dataset === :era5_land
+        isnothing(pressure_levels) ||
+            throw(ArgumentError("ERA5-Land has no pressure levels; use dataset = :era5 for pressure-level data"))
+        # reanalysis-era5-land requests take no product_type key
+        return "reanalysis-era5-land", nothing
+    else
+        throw(ArgumentError("Unknown dataset $(repr(dataset)); expected :era5 or :era5_land"))
+    end
+end
+
+"""
     hourly(; variables, startyear, months, days, hours, area=nothing,
-           pressure_levels=nothing, levels=nothing, format="netcdf", outputprefix="era5",
-           overwrite=false, threads=Threads.nthreads(), splitmonths=false, directory=".",
-           additional_kw...)
+           pressure_levels=nothing, levels=nothing, dataset=:era5, format="netcdf",
+           outputprefix="era5", overwrite=false, threads=Threads.nthreads(),
+           splitmonths=false, directory=".", additional_kw...)
 
 Download ERA5 hourly data using the CDS API. This function provides compatibility
 with NumericalEarth's ERA5 download interface.
@@ -23,6 +46,8 @@ with NumericalEarth's ERA5 download interface.
                      If provided, downloads from pressure-levels dataset instead of single-levels.
 - `levels`: The v0.1 (era5cli) spelling of `pressure_levels`: a vector of levels in hPa
             selects the pressure-levels dataset; `:surface` and `nothing` mean single-levels.
+- `dataset`: `:era5` (default) or `:era5_land` (`reanalysis-era5-land`, 0.1° land-only
+             reanalysis). ERA5-Land has no pressure levels.
 
 Returns a vector of downloaded file paths, one per variable.
 
@@ -32,8 +57,8 @@ A single variable keeps the v0.2 names (`outputprefix.nc` for a single date/hour
 name is appended to `outputprefix` so each request gets its own file.
 """
 function hourly(; variables::Union{String, AbstractVector{String}}, startyear::Int, months, days, hours,
-                  area=nothing, pressure_levels=nothing, levels=nothing, format::String="netcdf",
-                  outputprefix::String="era5", overwrite::Bool=false,
+                  area=nothing, pressure_levels=nothing, levels=nothing, dataset::Symbol=:era5,
+                  format::String="netcdf", outputprefix::String="era5", overwrite::Bool=false,
                   threads::Int=Threads.nthreads(), splitmonths::Bool=false,
                   directory::String=".", additional_kw...)
 
@@ -46,6 +71,8 @@ function hourly(; variables::Union{String, AbstractVector{String}}, startyear::I
         pressure_levels = levels
     end
 
+    dataset_id, product_type = resolve_dataset(dataset, pressure_levels)
+
     # Convert single values to arrays
     months_arr = months isa AbstractVector ? months : [months]
     days_arr = days isa AbstractVector ? days : [days]
@@ -56,13 +83,17 @@ function hourly(; variables::Union{String, AbstractVector{String}}, startyear::I
 
     # Build request parameters
     request_params = Dict(
-        "product_type" => "reanalysis",
         "format" => format,
         "year" => string(startyear),
         "month" => [string(m, pad=2) for m in months_arr],
         "day" => [string(d, pad=2) for d in days_arr],
         "time" => hours_str
     )
+
+    # ERA5-Land requests take no product_type key
+    if product_type !== nothing
+        request_params["product_type"] = product_type
+    end
 
     # Add area if specified - CDS API v2 expects [north, west, south, east] format
     if area !== nothing
@@ -98,8 +129,6 @@ function hourly(; variables::Union{String, AbstractVector{String}}, startyear::I
     # Skip files that exist when not overwriting
     pending = overwrite ? variables_arr : filter(variable -> !isfile(output_file(variable)), variables_arr)
 
-    dataset_id = pressure_levels === nothing ? "reanalysis-era5-single-levels" : "reanalysis-era5-pressure-levels"
-
     # One CDS request per variable, submitted concurrently
     if !isempty(pending)
         asyncmap(pending; ntasks=max(threads, 1)) do variable
@@ -129,6 +158,8 @@ files individually.
 - `month`: Month(s) to download - Integer (1-12) or Vector{Integer}
 - `area`: [south, west, north, east] bounding box (optional)
 - `pressure_levels`: Optional pressure levels in hPa (e.g., [1000, 850, 500])
+- `dataset`: `:era5` (default) or `:era5_land` (`reanalysis-era5-land`, 0.1° land-only
+             reanalysis). ERA5-Land has no pressure levels.
 - `format`: Output format (default: "netcdf")
 - `outputprefix`: Base filename prefix (default: "era5_monthly")
 - `directory`: Output directory (default: pwd())
@@ -173,6 +204,7 @@ function monthly(;
     month,
     area = nothing,
     pressure_levels = nothing,
+    dataset::Symbol = :era5,
     format = "netcdf",
     outputprefix = "era5_monthly",
     directory = pwd(),
@@ -180,6 +212,8 @@ function monthly(;
     threads = Threads.nthreads(),
     additional_kw...
 )
+    dataset_id, product_type = resolve_dataset(dataset, pressure_levels)
+
     # Normalize inputs to vectors
     var_list = variables isa String ? [variables] : collect(variables)
     year_list = year isa Integer ? [year] : collect(year)
@@ -215,7 +249,6 @@ function monthly(;
                 # Build CDS API request parameters for FULL MONTH
                 # All days (1-31), all hours (0-23) in ONE request
                 params = Dict{String, Any}(
-                    "product_type" => "reanalysis",
                     "variable" => [var],
                     "year" => [string(yr)],
                     "month" => [lpad(mon, 2, '0')],
@@ -223,6 +256,11 @@ function monthly(;
                     "time" => [string(h, pad=2) * ":00" for h in 0:23],  # ["00:00", ..., "23:00"]
                     "format" => format == "netcdf" ? "netcdf" : "grib"
                 )
+
+                # ERA5-Land requests take no product_type key
+                if product_type !== nothing
+                    params["product_type"] = product_type
+                end
 
                 # Add area constraint if specified
                 if !isnothing(area) && length(area) == 4
@@ -237,11 +275,9 @@ function monthly(;
                 end
 
                 region_str = isnothing(area) ? "global" : "regional"
-                dataset_str = isnothing(pressure_levels) ? "single-levels" : "pressure-levels"
-                @info "Downloading $var for $(yr)-$(lpad(mon, 2, '0')) ($dataset_str, $region_str)..."
+                @info "Downloading $var for $(yr)-$(lpad(mon, 2, '0')) ($dataset_id, $region_str)..."
 
                 # Download using direct CDS API
-                dataset_id = isnothing(pressure_levels) ? "reanalysis-era5-single-levels" : "reanalysis-era5-pressure-levels"
                 retrieve(dataset_id,
                         params,
                         output_path;
@@ -275,6 +311,8 @@ downloading hourly files individually.
 - `years`: Year(s) to download - Integer or range (e.g., 2000 or 2000:2010)
 - `area`: [north, west, south, east] bounding box (optional)
 - `pressure_levels`: Optional pressure levels in hPa (e.g., [1000, 850, 500])
+- `dataset`: `:era5` (default) or `:era5_land` (`reanalysis-era5-land`, 0.1° land-only
+             reanalysis). ERA5-Land has no pressure levels.
 - `format`: Output format (default: "netcdf")
 - `outputprefix`: Base filename prefix (default: "era5_yearly")
 - `directory`: Output directory (default: pwd())
@@ -309,6 +347,7 @@ function yearly(;
     years,
     area = nothing,
     pressure_levels = nothing,
+    dataset::Symbol = :era5,
     format = "netcdf",
     outputprefix = "era5_yearly",
     directory = pwd(),
@@ -316,6 +355,8 @@ function yearly(;
     threads = Threads.nthreads(),
     additional_kw...
 )
+    dataset_id, product_type = resolve_dataset(dataset, pressure_levels)
+
     # Normalize inputs to vectors
     var_list = variables isa String ? [variables] : collect(variables)
     year_list = years isa Integer ? [years] : collect(years)
@@ -349,7 +390,6 @@ function yearly(;
             # Build CDS API request parameters for FULL YEAR
             # All months, all days, all hours in ONE request
             params = Dict{String, Any}(
-                "product_type" => "reanalysis",
                 "variable" => [var],
                 "year" => [string(year)],
                 "month" => string.(1:12, pad=2),  # ["01", "02", ..., "12"]
@@ -357,6 +397,11 @@ function yearly(;
                 "time" => [string(h, pad=2) * ":00" for h in 0:23],  # ["00:00", ..., "23:00"]
                 "format" => format == "netcdf" ? "netcdf" : "grib"
             )
+
+            # ERA5-Land requests take no product_type key
+            if product_type !== nothing
+                params["product_type"] = product_type
+            end
 
             # Add area constraint if specified
             if !isnothing(area) && length(area) == 4
@@ -371,11 +416,9 @@ function yearly(;
             end
 
             region_str = isnothing(area) ? "global" : "regional"
-            dataset_str = isnothing(pressure_levels) ? "single-levels" : "pressure-levels"
-            @info "Downloading $var for year $year ($dataset_str, $region_str)..."
+            @info "Downloading $var for year $year ($dataset_id, $region_str)..."
 
             # Download using direct CDS API
-            dataset_id = isnothing(pressure_levels) ? "reanalysis-era5-single-levels" : "reanalysis-era5-pressure-levels"
             retrieve(dataset_id,
                     params,
                     output_path;

--- a/src/cds_client.jl
+++ b/src/cds_client.jl
@@ -215,6 +215,34 @@ function download_cds_file(url::String, output_path::String, credentials::CDSCre
     headers = ["PRIVATE-TOKEN" => credentials.key]
     request_with_retries(() -> Downloads.download(url, output_path; headers); what="CDS file download")
 
+    unwrap_zip_response!(output_path)
+
+    return output_path
+end
+
+# Some CDS datasets (e.g. reanalysis-era5-land) wrap their netcdf output in a zip
+# archive even when format=netcdf is requested, so a downloaded "*.nc" file may
+# actually be a zip. Detect the zip magic bytes and, if present, replace the file
+# in place with its single extracted member.
+function is_zip_file(path::String)
+    isfile(path) || return false
+    open(path, "r") do io
+        magic = read(io, 4)
+        return length(magic) == 4 && magic[1:2] == UInt8[0x50, 0x4b]
+    end
+end
+
+function unwrap_zip_response!(output_path::String)
+    is_zip_file(output_path) || return output_path
+
+    mktempdir() do tmpdir
+        run(`unzip -o -q $output_path -d $tmpdir`)
+        extracted = filter(isfile, readdir(tmpdir; join=true))
+        isempty(extracted) && error("CDS response at $output_path was a zip archive but contained no files")
+        length(extracted) > 1 && @warn "CDS zip response at $output_path contained multiple files; using the first" extracted
+        mv(first(extracted), output_path; force=true)
+    end
+
     return output_path
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,6 +77,43 @@ using CopernicusClimateDataStore
         end
     end
 
+    @testset "resolve_dataset (offline)" begin
+        @test CopernicusClimateDataStore.resolve_dataset(:era5, nothing) ==
+              ("reanalysis-era5-single-levels", "reanalysis")
+        @test CopernicusClimateDataStore.resolve_dataset(:era5, [1000, 850]) ==
+              ("reanalysis-era5-pressure-levels", "reanalysis")
+        @test CopernicusClimateDataStore.resolve_dataset(:era5_land, nothing) ==
+              ("reanalysis-era5-land", nothing)
+        @test_throws ArgumentError CopernicusClimateDataStore.resolve_dataset(:era5_land, [1000])
+        @test_throws ArgumentError CopernicusClimateDataStore.resolve_dataset(:bogus, nothing)
+    end
+
+    @testset "zip-wrapped CDS response unwrapping (offline)" begin
+        # reanalysis-era5-land wraps its netcdf output in a zip archive even when
+        # format=netcdf is requested; download_cds_file must transparently unwrap it.
+        mktempdir() do dir
+            payload_path = joinpath(dir, "data_0.nc")
+            write(payload_path, "fake netcdf bytes")
+
+            zip_path = joinpath(dir, "response.nc")
+            run(Cmd(`zip -j -q $zip_path $payload_path`))
+            @test CopernicusClimateDataStore.is_zip_file(zip_path)
+
+            CopernicusClimateDataStore.unwrap_zip_response!(zip_path)
+            @test !CopernicusClimateDataStore.is_zip_file(zip_path)
+            @test read(zip_path, String) == "fake netcdf bytes"
+        end
+
+        # A plain (non-zip) file is left untouched
+        mktempdir() do dir
+            plain_path = joinpath(dir, "plain.nc")
+            write(plain_path, "not a zip")
+            @test !CopernicusClimateDataStore.is_zip_file(plain_path)
+            CopernicusClimateDataStore.unwrap_zip_response!(plain_path)
+            @test read(plain_path, String) == "not a zip"
+        end
+    end
+
     @testset "ERA5 Download Integration Test" begin
         # Only run if CDS credentials are available
         has_credentials = try


### PR DESCRIPTION
## Summary

- `resolve_dataset(dataset, pressure_levels)` maps a new `dataset` keyword
  (`:era5`, the default, or `:era5_land`) to the right CDS product id and
  `product_type`, wired into `hourly()`, `monthly()`, and `yearly()`.
  `reanalysis-era5-land` takes no `product_type` key at all, unlike the
  single-levels/pressure-levels products.
- `download_cds_file` now detects and unwraps zip-wrapped CDS responses.
  `reanalysis-era5-land` was observed in practice to sometimes return a zip
  archive even when `format=netcdf` is explicitly requested; previously the
  raw zip bytes were written straight to the output path, so any netCDF
  reader downstream would fail on it. The fix checks the response for the
  zip magic bytes and, if present, extracts the single member in place.

## Motivation

Found while adding ERA5-Land support to NumericalEarth.jl
(NumericalEarth/NumericalEarth.jl#490): a live download of a full year of
hourly `reanalysis-era5-land` data succeeded at every CDS-side step but
failed downstream because one monthly chunk came back as a zip. This fixes
it at the source so any caller of `retrieve`/`download_cds_file` — not just
that one downstream extension — gets the requested format regardless of
what the gateway actually sends.

## Testing

New offline unit tests in `test/runtests.jl`: `resolve_dataset` for both
datasets and the pressure-levels/land-with-pressure-levels error case, and
`unwrap_zip_response!`/`is_zip_file` against a synthetic zip fixture and a
plain (non-zip) file that should be left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)