### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CopernicusClimateDataStore"
 uuid = "bce3f73f-acea-4481-bd86-df89ecc2cb46"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["NumericalEarth and lovely collaborators"]
 
 [deps]


### PR DESCRIPTION
Patch release covering #9: `:era5_land` dataset support and the zip-wrapped
CDS response fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)